### PR TITLE
Change default cookie expiration time to 30 mins

### DIFF
--- a/cognito_code_grant/signed_cookies.py
+++ b/cognito_code_grant/signed_cookies.py
@@ -17,7 +17,7 @@ def rsa_signer(message):
     return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())
 
 
-def generate_signed_cookies(resource=None,expire_minutes=5, assets_domain=None):
+def generate_signed_cookies(resource=None,expire_minutes=30, assets_domain=None):
     """
     @resource   path to s3 object inside bucket(or a wildcard path,e.g. '/blah/*' or  '*')
     @expire_minutes     how many minutes before we expire these access credentials (within cookie)


### PR DESCRIPTION
Increasing the cookie expiration time from 5 minutes to 30 mins.

Everytime the FE does a request to the BE, it gets fresh cookies, with expiration date of NOW+5min. So in theory, there shouldn't be a problem with the current 5 minutes expiration, since the FE usually makes a request to the BE, gets the BE response with the cookies + assets-v2 links, then hits the assets-v2 links already with the fresh cookies.

This increase is mostly a precautionary measure. It will help in cases where, for example:
- Hub users load a render, 5 mins go by, and only then click on the thumbnail download link
- FE might, in some odd circumstance, hit assets-v2 link 5 mins after the latest reply from the BE